### PR TITLE
Replace input key 'fullmtype' with 'mtype'

### DIFF
--- a/bluepymm/select_combos/process_megate_config.py
+++ b/bluepymm/select_combos/process_megate_config.py
@@ -59,7 +59,9 @@ def read_megate_thresholds(conf_dict):
             processed if available.
 
     Returns:
-        A tuple (<list_of_dicts>, <conf_dict['megate_thresholds']>)"""
+        A tuple (<list_of_dicts>, <conf_dict['megate_thresholds']>). The key
+        'mtype' is converted to its internal equivalent 'fullmtype'.
+    """
 
     megate_thresholds = conf_dict.get('megate_thresholds', [])
 
@@ -70,11 +72,13 @@ def read_megate_thresholds(conf_dict):
             'megate_threshold': megate_threshold_dict['megate_threshold'],
             'features': join_regex(megate_threshold_dict['features'])
         }
-        for key in ['emodel', 'fullmtype', 'etype']:
+        for key in ['emodel', 'mtype', 'etype']:
             if key in megate_threshold_dict:
                 megate_pattern[key] = join_regex(megate_threshold_dict[key])
             else:
                 megate_pattern[key] = re.compile('.*')
+        if 'mtype' in megate_pattern:
+            megate_pattern['fullmtype'] = megate_pattern.pop('mtype')
 
         megate_patterns.append(megate_pattern)
 

--- a/bluepymm/tests/examples/simple1/simple1_conf_select.json
+++ b/bluepymm/tests/examples/simple1/simple1_conf_select.json
@@ -4,7 +4,7 @@
    "to_skip_features": [],
    "pdf_filename": "output_megate/megating.pdf",
    "megate_thresholds": [
-       {"emodel": [".*"], "fullmtype": [".*"], "etype": [".*"], "features": [".*"], "megate_threshold": 5}
+       {"emodel": [".*"], "mtype": [".*"], "etype": [".*"], "features": [".*"], "megate_threshold": 5}
    ],
    "output_dir": "./output_megate",
    "check_opt_scores": true,

--- a/bluepymm/tests/examples/simple1/simple1_conf_select_2.json
+++ b/bluepymm/tests/examples/simple1/simple1_conf_select_2.json
@@ -4,7 +4,7 @@
    "to_skip_features": [],
    "pdf_filename": "output_megate/megating.pdf",
    "megate_thresholds": [
-       {"emodel": [".*"], "fullmtype": [".*"], "etype": [".*"], "features": [".*"], "megate_threshold": 5}
+       {"emodel": [".*"], "mtype": [".*"], "etype": [".*"], "features": [".*"], "megate_threshold": 5}
    ],
    "output_dir": "./output_megate",
    "skip_repaired_exemplar": false,

--- a/bluepymm/tests/test_process_megate_config.py
+++ b/bluepymm/tests/test_process_megate_config.py
@@ -72,7 +72,7 @@ def test_read_megate_thresholds():
 
     # all keys present
     test_dict = {'megate_thresholds': [
-        {'emodel': ['test1'], 'fullmtype': ['test2'], 'etype': ['test3'],
+        {'emodel': ['test1'], 'mtype': ['test2'], 'etype': ['test3'],
          'features': ['.*'], 'megate_threshold': 5}]}
     ret_patterns, ret_thresholds = proc_config.read_megate_thresholds(
         test_dict)
@@ -86,7 +86,7 @@ def test_read_megate_thresholds():
     nt.assert_equal(len(ret_patterns), len(expected_patterns))
     nt.assert_dict_equal(ret_patterns[0], expected_patterns[0])
 
-    # key 'fullmtype' not present
+    # key 'mtype' not present
     test_dict = {'megate_thresholds': [
         {'emodel': ['test1'], 'etype': ['test3'], 'features': ['.*'],
          'megate_threshold': 5}]}


### PR DESCRIPTION
Note: 'fullmtype' remains the internal term used.