### PR TITLE
new option for no apical + str for yaml

### DIFF
--- a/bluepymm/prepare_combos/parse_files.py
+++ b/bluepymm/prepare_combos/parse_files.py
@@ -129,9 +129,9 @@ def read_mm_recipe_yaml(recipe_filename):
     for region in recipe['neurons']:
         for etype in region['traits']['etype'].keys():
             n_combos = len(mecombos)
-            mecombos.loc[n_combos, 'layer'] = region['traits']['layer']
-            mecombos.loc[n_combos, 'fullmtype'] = region['traits']['mtype']
-            mecombos.loc[n_combos, 'etype'] = etype
+            mecombos.loc[n_combos, 'layer'] = str(region['traits']['layer'])
+            mecombos.loc[n_combos, 'fullmtype'] = str(region['traits']['mtype'])
+            mecombos.loc[n_combos, 'etype'] = str(etype)
     return mecombos
 
 

--- a/bluepymm/prepare_combos/parse_files.py
+++ b/bluepymm/prepare_combos/parse_files.py
@@ -128,10 +128,10 @@ def read_mm_recipe_yaml(recipe_filename):
     mecombos = pandas.DataFrame(columns=["layer", "fullmtype", "etype"])
     for region in recipe['neurons']:
         for etype in region['traits']['etype'].keys():
-            gid = len(mecombos)
-            mecombos.loc[gid, 'layer'] = str(region['traits']['layer'])
-            mecombos.loc[gid, 'fullmtype'] = str(region['traits']['mtype'])
-            mecombos.loc[gid, 'etype'] = str(etype)
+            end = len(mecombos)
+            mecombos.loc[end, 'layer'] = str(region['traits']['layer'])
+            mecombos.loc[end, 'fullmtype'] = str(region['traits']['mtype'])
+            mecombos.loc[end, 'etype'] = str(etype)
     return mecombos
 
 

--- a/bluepymm/prepare_combos/parse_files.py
+++ b/bluepymm/prepare_combos/parse_files.py
@@ -128,10 +128,10 @@ def read_mm_recipe_yaml(recipe_filename):
     mecombos = pandas.DataFrame(columns=["layer", "fullmtype", "etype"])
     for region in recipe['neurons']:
         for etype in region['traits']['etype'].keys():
-            n_combos = len(mecombos)
-            mecombos.loc[n_combos, 'layer'] = str(region['traits']['layer'])
-            mecombos.loc[n_combos, 'fullmtype'] = str(region['traits']['mtype'])
-            mecombos.loc[n_combos, 'etype'] = str(etype)
+            n = len(mecombos)
+            mecombos.loc[n, 'layer'] = str(region['traits']['layer'])
+            mecombos.loc[n, 'fullmtype'] = str(region['traits']['mtype'])
+            mecombos.loc[n, 'etype'] = str(etype)
     return mecombos
 
 

--- a/bluepymm/prepare_combos/parse_files.py
+++ b/bluepymm/prepare_combos/parse_files.py
@@ -128,10 +128,10 @@ def read_mm_recipe_yaml(recipe_filename):
     mecombos = pandas.DataFrame(columns=["layer", "fullmtype", "etype"])
     for region in recipe['neurons']:
         for etype in region['traits']['etype'].keys():
-            n = len(mecombos)
-            mecombos.loc[n, 'layer'] = str(region['traits']['layer'])
-            mecombos.loc[n, 'fullmtype'] = str(region['traits']['mtype'])
-            mecombos.loc[n, 'etype'] = str(etype)
+            gid = len(mecombos)
+            mecombos.loc[gid, 'layer'] = str(region['traits']['layer'])
+            mecombos.loc[gid, 'fullmtype'] = str(region['traits']['mtype'])
+            mecombos.loc[gid, 'etype'] = str(etype)
     return mecombos
 
 

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -300,7 +300,7 @@ def prepare_emodel_dirs(
              continu))
 
     print('Parallelising preparation of e-model directories')
-    pool = multiprocessing.Pool(processes=1, maxtasksperchild=1)
+    pool = multiprocessing.Pool(maxtasksperchild=1)
     emodel_dirs = {}
     for emodel_dir_dict in pool.map(prepare_emodel_dir, arg_list, chunksize=1):
         for emodel, emodel_dir in emodel_dir_dict.items():

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -300,10 +300,9 @@ def prepare_emodel_dirs(
              continu))
 
     print('Parallelising preparation of e-model directories')
-    pool = multiprocessing.Pool(maxtasksperchild=1)
+    pool = multiprocessing.Pool(processes=1, maxtasksperchild=1)
     emodel_dirs = {}
     for emodel_dir_dict in pool.map(prepare_emodel_dir, arg_list, chunksize=1):
         for emodel, emodel_dir in emodel_dir_dict.items():
             emodel_dirs[emodel] = emodel_dir
-
     return emodel_dirs

--- a/bluepymm/run_combos/calculate_scores.py
+++ b/bluepymm/run_combos/calculate_scores.py
@@ -217,14 +217,10 @@ def create_arg_list(scores_db_filename, emodel_dirs, final_dict,
 
         apical_points_isec = {}
         setup = tools.load_module('setup', emodel_dirs[one_row['emodel']])
-        if hasattr(setup, 'multieval'):
-            if use_apical_points:
-                apical_points_isec = tools.load_json(
-                    os.path.join(one_row['morph_dir'],
-                                 "apical_points_isec.json")
-                )
-            else:
-                apical_points_isec = {}
+        if hasattr(setup, 'multieval') and use_apical_points:
+            apical_points_isec = tools.load_json(
+                os.path.join(one_row['morph_dir'], "apical_points_isec.json")
+            )
 
         scores_cursor = scores_db.execute('SELECT * FROM scores')
         for row in scores_cursor.fetchall():

--- a/bluepymm/run_combos/calculate_scores.py
+++ b/bluepymm/run_combos/calculate_scores.py
@@ -139,7 +139,6 @@ def run_emodel_morph(
             if hasattr(setup, 'multieval'):
 
                 prefix = 'mm'
-
                 altmorph = [[prefix, morph_path, apical_point_isec]]
                 evaluator = setup.evaluator.create(etype='%s' % emodel,
                                                    altmorph=altmorph)
@@ -218,9 +217,13 @@ def create_arg_list(scores_db_filename, emodel_dirs, final_dict,
         apical_points_isec = {}
         setup = tools.load_module('setup', emodel_dirs[one_row['emodel']])
         if hasattr(setup, 'multieval'):
-            apical_points_isec = tools.load_json(
-                os.path.join(one_row['morph_dir'], "apical_points_isec.json")
-            )
+            try:
+                apical_points_isec = tools.load_json(
+                    os.path.join(one_row['morph_dir'], "apical_points_isec.json")
+                )
+            except IOError:
+                apical_points_isec = {}
+                print('Warning: no apical_points_isec.json found!')
 
         scores_cursor = scores_db.execute('SELECT * FROM scores')
         for row in scores_cursor.fetchall():

--- a/bluepymm/run_combos/main.py
+++ b/bluepymm/run_combos/main.py
@@ -57,7 +57,7 @@ def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
     scores_db_path = os.path.abspath(conf_dict['scores_db'])
 
     if 'use_apical_points' in conf_dict:
-        use_apical_points = conf_dict['use_apical_points'] 
+        use_apical_points = conf_dict['use_apical_points']
     else:
         use_apical_points = True
 

--- a/bluepymm/run_combos/main.py
+++ b/bluepymm/run_combos/main.py
@@ -56,6 +56,11 @@ def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
             'emodel_dirs.json'))
     scores_db_path = os.path.abspath(conf_dict['scores_db'])
 
+    if 'use_apical_points' in conf_dict:
+        use_apical_points = conf_dict['use_apical_points'] 
+    else:
+        use_apical_points = True
+
     print('Calculating scores')
     calculate_scores.calculate_scores(
         final_dict,
@@ -64,8 +69,7 @@ def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
         use_ipyp=ipyp,
         ipyp_profile=ipyp_profile,
         timeout=timeout,
-        use_apical_points=(conf_dict['use_apical_points']
-                           if 'use_apical_points' in conf_dict else True))
+        use_apical_points=use_apical_points)
 
 
 def run_combos(conf_filename, ipyp=None, ipyp_profile=None):

--- a/bluepymm/run_combos/main.py
+++ b/bluepymm/run_combos/main.py
@@ -63,7 +63,9 @@ def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
         scores_db_path,
         use_ipyp=ipyp,
         ipyp_profile=ipyp_profile,
-        timeout=timeout)
+        timeout=timeout,
+        use_apical_points=(conf_dict['use_apical_points']
+                           if 'use_apical_points' in conf_dict else True))
 
 
 def run_combos(conf_filename, ipyp=None, ipyp_profile=None):

--- a/bluepymm/tests/examples/simple1/simple1_conf_run.json
+++ b/bluepymm/tests/examples/simple1/simple1_conf_run.json
@@ -1,5 +1,6 @@
 {
     "version": "1.0",
     "scores_db": "./output/scores.sqlite",
-    "output_dir": "./output/"
+    "output_dir": "./output/",
+    "use_apical_points": false
 }

--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -382,7 +382,8 @@ def test_calculate_scores():
             run_combos.calculate_scores.calculate_scores(final_dict,
                                                          emodel_dirs,
                                                          test_db_filename,
-                                                         use_ipyp=use_ipyp
+                                                         use_ipyp=use_ipyp,
+                                                         use_apical_points=False
                                                          )
 
         if use_ipyp:

--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -379,12 +379,13 @@ def test_calculate_scores():
             time.sleep(10)
 
         with tools.cd(TEST_DIR):
-            run_combos.calculate_scores.calculate_scores(final_dict,
-                                                         emodel_dirs,
-                                                         test_db_filename,
-                                                         use_ipyp=use_ipyp,
-                                                         use_apical_points=False
-                                                         )
+            run_combos.calculate_scores.calculate_scores(
+                final_dict,
+                emodel_dirs,
+                test_db_filename,
+                use_ipyp=use_ipyp,
+                use_apical_points=False
+            )
 
         if use_ipyp:
             ip_proc.terminate()

--- a/bluepymm/tests/test_parse_files.py
+++ b/bluepymm/tests/test_parse_files.py
@@ -158,10 +158,10 @@ def test_read_mm_recipe_yaml():
     recipe_filename = os.path.join(
         BASE_DIR,
         'examples/simple1/data/simple1_recipe.yaml')
-    expected_records = [(1, "mtype1", "etype1"),
-                        (1, "mtype1", "etype2"),
-                        (1, "mtype2", "etype1"),
-                        (2, "mtype1", "etype2"), ]
+    expected_records = [("1", "mtype1", "etype1"),
+                        ("1", "mtype1", "etype2"),
+                        ("1", "mtype2", "etype1"),
+                        ("2", "mtype1", "etype2"), ]
     expected_df = pandas.DataFrame(expected_records,
                                    columns=["layer", "fullmtype", "etype"],
                                    )

--- a/bluepymm/tests/test_run_combos.py
+++ b/bluepymm/tests/test_run_combos.py
@@ -54,3 +54,8 @@ def test_run_combos():
 
         # verify output
         _verify_run_combos_output(config['scores_db'])
+
+        # with use_apical_points
+        config['use_apical_points'] = False
+        run_combos.main.run_combos_from_conf(config)
+        _verify_run_combos_output(config['scores_db'])

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     name="bluepymm",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=['sh', 'bluepyopt', 'matplotlib', 'pandas', 'numpy',
+    install_requires=['sh', 'bluepyopt', 'matplotlib', 'pandas', 'numpy', 'NEURON',
                       'ipyparallel', 'lxml', 'h5py', 'pyyaml'],
     packages=setuptools.find_packages(exclude=('notebook',)),
     author="BlueBrain Project, EPFL",

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ setenv =
     PYTHONPATH={env:TOX_NRNDIR}/local/lib/python:{env:TOX_NRNDIR}/local/lib64/python
 commands =
     make clean
-    ./.install_neuron.sh {env:TOX_NRNDIR}/src {env:TOX_NRNDIR}/local {basepython} 
+    ; ./.install_neuron.sh {env:TOX_NRNDIR}/src {env:TOX_NRNDIR}/local {basepython} 
 
-    make toxbinlinks
+    ; make toxbinlinks
 
     make simple1_git
     style: pycodestyle --ignore=E402,W503,W504 bluepymm

--- a/tox.ini
+++ b/tox.ini
@@ -39,3 +39,6 @@ deps =
     sphinx_rtd_theme
 commands = make html
 whitelist_externals = make
+
+[pycodestyle]
+max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,3 @@ deps =
     sphinx_rtd_theme
 commands = make html
 whitelist_externals = make
-
-[pycodestyle]
-max-line-length = 100


### PR DESCRIPTION
New parameter use_apical_points in the config dict to disable the use of apical_points.
Small bug from previous PR on allowing for yaml recipe file, the layer info should be a str so that dataframe.merge can add the etypes to the dataframes. 