### PR TITLE
Introducing number of processes argument

### DIFF
--- a/bluepymm/main.py
+++ b/bluepymm/main.py
@@ -51,7 +51,8 @@ def run(arg_list):
 
     if args.action == "prepare":
         prepare_combos.prepare_combos(conf_filename=args.conf_filename,
-                                      continu=args.continu)
+                                      continu=args.continu,
+                                      n_processes=args.n_processes)
     elif args.action == "run":
         run_combos.run_combos(conf_filename=args.conf_filename,
                               ipyp=args.ipyp,

--- a/bluepymm/main.py
+++ b/bluepymm/main.py
@@ -56,7 +56,8 @@ def run(arg_list):
     elif args.action == "run":
         run_combos.run_combos(conf_filename=args.conf_filename,
                               ipyp=args.ipyp,
-                              ipyp_profile=args.ipyp_profile)
+                              ipyp_profile=args.ipyp_profile,
+                              n_processes=args.n_processes)
     elif args.action == "select":
         select_combos.select_combos(conf_filename=args.conf_filename)
     elif args.action == "validate":

--- a/bluepymm/main.py
+++ b/bluepymm/main.py
@@ -59,7 +59,8 @@ def run(arg_list):
                               ipyp_profile=args.ipyp_profile,
                               n_processes=args.n_processes)
     elif args.action == "select":
-        select_combos.select_combos(conf_filename=args.conf_filename)
+        select_combos.select_combos(conf_filename=args.conf_filename,
+                                    n_processes=args.n_processes)
     elif args.action == "validate":
         validate_output.validate_output(conf_filename=args.conf_filename)
 

--- a/bluepymm/prepare_combos/main.py
+++ b/bluepymm/prepare_combos/main.py
@@ -97,7 +97,7 @@ def prepare_emodels(conf_dict, continu, scores_db_path, n_processes):
     return final_dict, emodel_dirs
 
 
-def prepare_combos(conf_filename, continu, n_processes):
+def prepare_combos(conf_filename, continu, n_processes=None):
     """Prepare combos"""
 
     print('Reading configuration at %s' % conf_filename)

--- a/bluepymm/prepare_combos/main.py
+++ b/bluepymm/prepare_combos/main.py
@@ -29,7 +29,7 @@ from . import prepare_emodel_dirs as prepare_dirs
 from . import create_mm_sqlite
 
 
-def prepare_emodels(conf_dict, continu, scores_db_path):
+def prepare_emodels(conf_dict, continu, scores_db_path, n_processes):
     """Prepare emodels"""
 
     tmp_dir = conf_dict['tmp_dir']
@@ -52,7 +52,7 @@ def prepare_emodels(conf_dict, continu, scores_db_path):
     # Clone the emodels repo and prepare the dirs for all the emodels
     emodel_dirs = prepare_dirs.prepare_emodel_dirs(
         final_dict, emodel_etype_map, emodels_dir, opt_dir, emodels_hoc_dir,
-        emodels_in_repo, continu=continu)
+        emodels_in_repo, continu=continu, n_processes=n_processes)
 
     if not continu:
         print('Creating sqlite db at %s' % scores_db_path)
@@ -97,7 +97,7 @@ def prepare_emodels(conf_dict, continu, scores_db_path):
     return final_dict, emodel_dirs
 
 
-def prepare_combos(conf_filename, continu):
+def prepare_combos(conf_filename, continu, n_processes):
     """Prepare combos"""
 
     print('Reading configuration at %s' % conf_filename)
@@ -105,7 +105,7 @@ def prepare_combos(conf_filename, continu):
     scores_db_path = os.path.abspath(conf_dict['scores_db'])
 
     final_dict, emodel_dirs = prepare_emodels(
-        conf_dict, continu, scores_db_path)
+        conf_dict, continu, scores_db_path, n_processes)
 
     # Save output
     # TODO: gather all output business here?
@@ -124,3 +124,5 @@ def add_parser(action):
     parser.add_argument('conf_filename')
     parser.add_argument('--continu', action='store_true',
                         help='continue from previous run')
+    parser.add_argument('--n_processes', help='number of processes',
+                        type=int)

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -261,7 +261,9 @@ def prepare_emodel_dirs(
         opt_dir,
         emodels_hoc_dir,
         emodels_in_repo,
-        continu=False):
+        continu=False,
+        n_processes=None
+        ):
     """Prepare the directories for the emodels.
 
     Args:
@@ -298,9 +300,9 @@ def prepare_emodel_dirs(
              emodels_hoc_dir,
              emodels_in_repo,
              continu))
-
     print('Parallelising preparation of e-model directories')
-    pool = multiprocessing.Pool(maxtasksperchild=1)
+    pool = multiprocessing.Pool(processes=n_processes,
+                                maxtasksperchild=1)
     emodel_dirs = {}
     for emodel_dir_dict in pool.map(prepare_emodel_dir, arg_list, chunksize=1):
         for emodel, emodel_dir in emodel_dir_dict.items():

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -255,15 +255,15 @@ def prepare_emodel_dir(input_args):
 
 
 def prepare_emodel_dirs(
-        final_dict,
-        emodel_etype_map,
-        emodels_dir,
-        opt_dir,
-        emodels_hoc_dir,
-        emodels_in_repo,
-        continu=False,
-        n_processes=None
-        ):
+    final_dict,
+    emodel_etype_map,
+    emodels_dir,
+    opt_dir,
+    emodels_hoc_dir,
+    emodels_in_repo,
+    continu=False,
+    n_processes=None,
+):
     """Prepare the directories for the emodels.
 
     Args:

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -302,11 +302,24 @@ def prepare_emodel_dirs(
              emodels_hoc_dir,
              emodels_in_repo,
              continu))
-    print('Parallelising preparation of e-model directories')
-    pool = multiprocessing.Pool(processes=n_processes,
-                                maxtasksperchild=1)
+
     emodel_dirs = {}
-    for emodel_dir_dict in pool.map(prepare_emodel_dir, arg_list, chunksize=1):
+    emodel_dir_dicts = []
+
+    if n_processes == 1:
+        for arg in arg_list:
+            emodel_dir_dict = prepare_emodel_dir(arg)
+            emodel_dir_dicts.append(emodel_dir_dict)
+    else:
+        print('Parallelising preparation of e-model directories')
+        pool = multiprocessing.Pool(processes=n_processes,
+                                    maxtasksperchild=1)
+        for emodel_dir_dict in pool.map(prepare_emodel_dir, arg_list,
+                                        chunksize=1):
+            emodel_dir_dicts.append(emodel_dir_dict)
+
+    for emodel_dir_dict in emodel_dir_dicts:
         for emodel, emodel_dir in emodel_dir_dict.items():
             emodel_dirs[emodel] = emodel_dir
+
     return emodel_dirs

--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -280,6 +280,8 @@ def prepare_emodel_dirs(
             into separate subdirectories.
         continu: True if this BluePyMM run builds on a previous run, False
             otherwise. Default is False.
+        n_processes: the integer number of processes. If `None`,
+        all processes are going to be used.
 
     Return:
         A dict mapping e-models to prepared e-model directories.

--- a/bluepymm/run_combos/main.py
+++ b/bluepymm/run_combos/main.py
@@ -82,4 +82,5 @@ def run_combos(conf_filename, ipyp=None, ipyp_profile=None, n_processes=None):
     print('Reading configuration at %s' % conf_filename)
     conf_dict = tools.load_json(conf_filename)
 
-    run_combos_from_conf(conf_dict, ipyp, ipyp_profile, n_processes)
+    run_combos_from_conf(conf_dict, ipyp, ipyp_profile,
+                         n_processes=n_processes)

--- a/bluepymm/run_combos/main.py
+++ b/bluepymm/run_combos/main.py
@@ -41,9 +41,12 @@ def add_parser(action):
                         help='Path to ipyparallel profile')
     parser.add_argument('--timeout',
                         help='Timeout for ipyparallel clients')
+    parser.add_argument('--n_processes', help='number of processes',
+                        type=int)
 
 
-def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
+def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10,
+                         n_processes=None):
     """Run combos from conf dictionary"""
     output_dir = conf_dict['output_dir']
     final_dict = tools.load_json(
@@ -69,13 +72,14 @@ def run_combos_from_conf(conf_dict, ipyp=None, ipyp_profile=None, timeout=10):
         use_ipyp=ipyp,
         ipyp_profile=ipyp_profile,
         timeout=timeout,
-        use_apical_points=use_apical_points)
+        use_apical_points=use_apical_points,
+        n_processes=n_processes)
 
 
-def run_combos(conf_filename, ipyp=None, ipyp_profile=None):
+def run_combos(conf_filename, ipyp=None, ipyp_profile=None, n_processes=None):
     """Run combos"""
 
     print('Reading configuration at %s' % conf_filename)
     conf_dict = tools.load_json(conf_filename)
 
-    run_combos_from_conf(conf_dict, ipyp, ipyp_profile)
+    run_combos_from_conf(conf_dict, ipyp, ipyp_profile, n_processes)

--- a/bluepymm/select_combos/main.py
+++ b/bluepymm/select_combos/main.py
@@ -31,20 +31,21 @@ from . import sqlite_io, reporting, megate_output
 from . import process_megate_config as proc_config
 
 
-def select_combos(conf_filename):
+def select_combos(conf_filename, n_processes):
     """Parse conf file and run select combos"""
     # Parse configuration file
     conf_dict = tools.load_json(conf_filename)
 
-    select_combos_from_conf(conf_dict)
+    select_combos_from_conf(conf_dict, n_processes)
 
 
-def select_combos_from_conf(conf_dict):
+def select_combos_from_conf(conf_dict, n_processes=None):
     """Compare scores of me-combinations to thresholds, select successful
     combinations, and write results out to file.
 
     Args:
         conf_filename: filename of configuration (.json file)
+        n_processes: integer number of processes, `None` will use all of them
     """
     scores_db_filename = conf_dict['scores_db']
     pdf_filename = conf_dict['pdf_filename']
@@ -85,7 +86,8 @@ def select_combos_from_conf(conf_dict):
             scores, score_values,
             conf_dict.get('plot_emodels_per_morphology', False),
             output_dir,
-            select_perc_best)
+            select_perc_best,
+            n_processes=n_processes)
     print('Wrote pdf to %s' % os.path.abspath(pdf_filename))
 
     # write output files
@@ -112,3 +114,5 @@ def add_parser(action):
     parser = action.add_parser('select',
                                help='Select feasible me-combinations')
     parser.add_argument('conf_filename')
+    parser.add_argument('--n_processes', help='number of processes',
+                        type=int)

--- a/bluepymm/select_combos/reporting.py
+++ b/bluepymm/select_combos/reporting.py
@@ -330,7 +330,8 @@ def create_final_db_and_write_report(pdf_filename,
                                      score_values,
                                      enable_plot_emodels_per_morphology,
                                      output_dir,
-                                     select_perc_best):
+                                     select_perc_best,
+                                     n_processes=None):
     """Create the final output files and report"""
     ext_neurondb = pandas.DataFrame()
 
@@ -362,7 +363,9 @@ def create_final_db_and_write_report(pdf_filename,
                                                         megate_patterns,
                                                         skip_repaired_exemplar,
                                                         check_opt_scores,
-                                                        select_perc_best)
+                                                        select_perc_best,
+                                                        n_processes=n_processes
+                                                        )
 
         print("All emodels processed, generating output files")
 

--- a/bluepymm/select_combos/table_processing.py
+++ b/bluepymm/select_combos/table_processing.py
@@ -269,7 +269,8 @@ def process_emodels(emodels,
                     megate_patterns,
                     skip_repaired_exemplar,
                     enable_check_opt_scores,
-                    select_perc_best):
+                    select_perc_best,
+                    n_processes=None):
 
     arg_list = [(emodel,
                  scores,
@@ -281,7 +282,7 @@ def process_emodels(emodels,
                  select_perc_best) for emodel in emodels]
 
     print('Parallelising selection processing of e-models')
-    pool = multiprocessing.Pool(maxtasksperchild=1)
+    pool = multiprocessing.Pool(maxtasksperchild=1, processes=n_processes)
     emodel_infos = {}
     for emodel, emodel_info in pool.imap(process_emodel, arg_list,
                                          chunksize=1):

--- a/bluepymm/select_combos/table_processing.py
+++ b/bluepymm/select_combos/table_processing.py
@@ -281,16 +281,22 @@ def process_emodels(emodels,
                  enable_check_opt_scores,
                  select_perc_best) for emodel in emodels]
 
-    print('Parallelising selection processing of e-models')
-    pool = multiprocessing.Pool(maxtasksperchild=1, processes=n_processes)
     emodel_infos = {}
-    for emodel, emodel_info in pool.imap(process_emodel, arg_list,
-                                         chunksize=1):
-        print('Received processed info from e-model %s' % emodel)
-        emodel_infos[emodel] = emodel_info
 
-    pool.terminate()
-    pool.join()
+    if n_processes == 1:
+        for args in arg_list:
+            emodel, emodel_info = process_emodel(args)
+            emodel_infos[emodel] = emodel_info
+    else:
+        print('Parallelising selection processing of e-models')
+        pool = multiprocessing.Pool(maxtasksperchild=1, processes=n_processes)
+        for emodel, emodel_info in pool.imap(process_emodel, arg_list,
+                                             chunksize=1):
+            print('Received processed info from e-model %s' % emodel)
+            emodel_infos[emodel] = emodel_info
+
+        pool.terminate()
+        pool.join()
 
     return emodel_infos
 

--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -383,7 +383,8 @@ def test_calculate_scores():
                 final_dict,
                 emodel_dirs,
                 test_db_filename,
-                use_ipyp=use_ipyp
+                use_ipyp=use_ipyp,
+                n_processes=1
             )
 
         if use_ipyp:

--- a/bluepymm/tests/test_prepare_emodel_dirs.py
+++ b/bluepymm/tests/test_prepare_emodel_dirs.py
@@ -257,9 +257,10 @@ def test_prepare_emodel_dir():
 
 
 @attr('unit')
-def test_prepare_emodel_dirs():
-    """prepare_combos.prepare_emodel_dirs: test prepare_emodel_dirs
-    based on test example 'simple1'.
+def test_prepare_emodel_dirs_single_process():
+    """prepare_combos.prepare_emodel_dirs_single_process:
+    test prepare_emodel_dirs based on test example 'simple1
+    using a single process'.
     """
     # create test directory, where output of this test will be created
     test_dir = os.path.join(TMP_DIR, 'test_prepare_emodel_dirs')
@@ -301,6 +302,61 @@ def test_prepare_emodel_dirs():
         ret = prepare_emodel_dirs.prepare_emodel_dirs(
             final_dict, emodel_etype_map, emodels_dir, opt_dir,
             emodels_hoc_dir, emodels_in_repo, continu, n_processes=1)
+
+    # verify output
+    expected_ret = {emodel: os.path.join(
+        emodels_dir, emodel) for emodel in final_dict}
+    nt.assert_dict_equal(ret, expected_ret)
+    nt.assert_true(os.path.isdir(emodels_dir))
+    nt.assert_true(os.path.isdir(emodels_hoc_dir))
+
+
+@attr('unit')
+def test_prepare_emodel_dirs_multi_process():
+    """prepare_combos.prepare_emodel_dirs_multi_process:
+    test prepare_emodel_dirs based on test example 'simple1'
+    using multiprocessing.
+    """
+    # create test directory, where output of this test will be created
+    test_dir = os.path.join(TMP_DIR, 'test_prepare_emodel_dirs')
+    tools.makedirs(test_dir)
+
+    # input parameters
+    final_dict = {'emodel1': {'main_path': '.',
+                              'seed': 2,
+                              'rank': 0,
+                              'notes': '',
+                              'branch': 'emodel1',
+                              'params': {'cm': 1.0},
+                              'fitness': {'Step1.SpikeCount': 20.0},
+                              'score': 104.72906197480131,
+                              'morph_path': 'morphologies/morph1.asc'},
+                  'emodel2': {'main_path': '.',
+                              'seed': 2,
+                              'rank': 0,
+                              'notes': '',
+                              'branch': 'emodel2',
+                              'params': {'cm': 0.5},
+                              'fitness': {'Step1.SpikeCount': 20.0},
+                              'score': 104.72906197480131,
+                              'morph_path': 'morphologies/morph2.asc'}}
+    emodel_etype_map = {'emodel1': {'mm_recipe': 'emodel1',
+                                    'etype': 'etype1',
+                                    'layer': ['1', 'str1']},
+                        'emodel2': {'mm_recipe': 'emodel2',
+                                    'etype': 'etype2',
+                                    'layer': ['1', '2']}}
+    emodels_dir = os.path.join(test_dir, 'tmp/emodels/')
+    opt_dir = os.path.join(TEST_DATA_DIR, 'data/emodels_dir/subdir/')
+    emodels_hoc_dir = os.path.join(test_dir, './output/emodels_hoc/')
+    emodels_in_repo = False
+    continu = False
+
+    # run function
+    with tools.cd(TEST_DATA_DIR):
+        ret = prepare_emodel_dirs.prepare_emodel_dirs(
+            final_dict, emodel_etype_map, emodels_dir, opt_dir,
+            emodels_hoc_dir, emodels_in_repo, continu, n_processes=None)
 
     # verify output
     expected_ret = {emodel: os.path.join(

--- a/bluepymm/tests/test_prepare_emodel_dirs.py
+++ b/bluepymm/tests/test_prepare_emodel_dirs.py
@@ -300,7 +300,7 @@ def test_prepare_emodel_dirs():
     with tools.cd(TEST_DATA_DIR):
         ret = prepare_emodel_dirs.prepare_emodel_dirs(
             final_dict, emodel_etype_map, emodels_dir, opt_dir,
-            emodels_hoc_dir, emodels_in_repo, continu)
+            emodels_hoc_dir, emodels_in_repo, continu, n_processes=1)
 
     # verify output
     expected_ret = {emodel: os.path.join(

--- a/bluepymm/tests/test_select_combos.py
+++ b/bluepymm/tests/test_select_combos.py
@@ -64,14 +64,14 @@ def _config_select_combos(config_template_path, tmp_dir):
 
 
 def _test_select_combos(test_data_dir, tmp_dir, config_template_path,
-                        benchmark_dir):
+                        benchmark_dir, n_processes=None):
     """Helper function to perform functional test of select_combos"""
     with tools.cd(test_data_dir):
         # prepare input data
         config = _config_select_combos(config_template_path, tmp_dir)
 
         # run combination selection
-        select_combos.main.select_combos_from_conf(config)
+        select_combos.main.select_combos_from_conf(config, n_processes)
 
         # verify output
         _verify_output(benchmark_dir, config['output_dir'])
@@ -84,7 +84,7 @@ def test_select_combos():
     tmp_dir = os.path.join(TMP_DIR, 'test_select_combos')
 
     _test_select_combos(TEST_DATA_DIR, tmp_dir, config_template_path,
-                        benchmark_dir)
+                        benchmark_dir, n_processes=1)
 
 
 def test_select_combos_2():


### PR DESCRIPTION
This PR allows users to specify the number of processes to be used in the `prepare`, `run` and `select` steps.

If the parameter is not specified, the default parallel processing behaviour of BluePyMM (that uses all of the available cores) is in place. 
A small number of processes can be specified when the amount of combos do not fit in the memory as in #203 .


The usage is as follows.

 `bluepymm prepare prepare.json --n_processes=1`
 `bluepymm run run.json --n_processes=8`
 `bluepymm select select.json --n_processes=2`
