### PR TITLE
decode the bstrings coming from circuitmvd3 to str

### DIFF
--- a/bluepymm/prepare_combos/parse_files.py
+++ b/bluepymm/prepare_combos/parse_files.py
@@ -32,6 +32,8 @@ import os
 import lxml
 import lxml.etree
 
+from bluepymm import tools
+
 
 def _parse_xml_tree(filename):
     """Read xml tree from file.
@@ -224,6 +226,11 @@ def read_circuitmvd3(circuitmvd3_path):
                    for cell_etype_id in cell_etype_ids]
     cell_morphs = [morph_ids[cell_morph_id]
                    for cell_morph_id in cell_morph_ids]
+
+    cell_layers = [tools.decode_bstring(layer) for layer in cell_layers]
+    cell_mtypes = [tools.decode_bstring(mtype) for mtype in cell_mtypes]
+    cell_etypes = [tools.decode_bstring(etype) for etype in cell_etypes]
+    cell_morphs = [tools.decode_bstring(morph) for morph in cell_morphs]
 
     # Write out in order layer, fullmtype, etype, morph
 

--- a/bluepymm/tests/test_tools.py
+++ b/bluepymm/tests/test_tools.py
@@ -179,3 +179,14 @@ def test_get_neuron_compliant_template_name():
     nt.assert_false(tools.check_compliance_with_neuron(name))
     ret = tools.get_neuron_compliant_template_name(name)
     nt.assert_true(tools.check_compliance_with_neuron(ret))
+
+
+@attr('unit')
+def test_decode_bstring():
+    """bluepymm.tools test the bstring decoding function."""
+    bstr_obj = b"this is a byte string"
+    decoded_bstr = "this is a byte string"
+    nt.assert_equal(tools.decode_bstring(bstr_obj), decoded_bstr)
+
+    str_obj = "this is a string"
+    nt.assert_equal(tools.decode_bstring(str_obj), str_obj)

--- a/bluepymm/tools.py
+++ b/bluepymm/tools.py
@@ -167,6 +167,23 @@ def shorten_and_hash_string(label, keep_length=40, hash_length=9):
     return '{}_{}'.format(label[0:keep_length], hash_string[0:hash_length])
 
 
+def decode_bstring(bstr_obj):
+    """Decodes and returns the str object from bytes.
+
+    Args:
+        bstr_obj: the bytes string object
+    Returns:
+        string object if conversion is successful, input object otherwise.
+    """
+
+    try:
+        decode_bstring = bstr_obj.decode()
+    except (UnicodeDecodeError, AttributeError):
+        print("Warning: decoding of bstring failed, returning the input.")
+        return bstr_obj
+    return decode_bstring
+
+
 def get_neuron_compliant_template_name(name):
     """Get template name that is compliant with NEURON based on given name.
 


### PR DESCRIPTION
h5py 3.0.0 is reading certain string fields as bytes.
This PR adds a helper function to make sure byte strings are converted to strings.

I couldn't find a simpler solution using the h5py API to specify the default data type while reading the file in the first place.