### PR TITLE
test_calculate_scores: explicitly call ipcluster stop

### DIFF
--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -389,8 +389,7 @@ def test_calculate_scores():
 
         if use_ipyp:
             ip_proc.terminate()
-            subprocess.run(["ipcluster", "stop"], capture_output=True,
-                           check=True)
+            subprocess.run(["ipcluster", "stop"], check=True)
 
         # verify database
         scores = {'Step1.SpikeCount': 20.0}

--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -389,7 +389,7 @@ def test_calculate_scores():
 
         if use_ipyp:
             ip_proc.terminate()
-            subprocess.run(["ipcluster", "stop"], check=True)
+            subprocess.Popen(["ipcluster", "stop"])
 
         # verify database
         scores = {'Step1.SpikeCount': 20.0}

--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -389,6 +389,8 @@ def test_calculate_scores():
 
         if use_ipyp:
             ip_proc.terminate()
+            subprocess.run(["ipcluster", "stop"], capture_output=True,
+                           check=True)
 
         # verify database
         scores = {'Step1.SpikeCount': 20.0}


### PR DESCRIPTION
This ipyparallel issue recently started causing Jenkins CI plan to fail.
I couldn't reproduce the issue myself but I think this explicit call to `ipcluster stop` can fix it. 
Even if it doesn't, explicit is still better than implicit.