### PR TITLE
remove the 640 character output limit on nosetest.assert_equal

### DIFF
--- a/bluepymm/tests/test_calculate_scores.py
+++ b/bluepymm/tests/test_calculate_scores.py
@@ -37,6 +37,7 @@ from nose.tools import with_setup
 import bluepymm.run_combos as run_combos
 from bluepymm import tools
 
+nt.assert_equal.__self__.maxDiff = None
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TEST_DIR = os.path.join(BASE_DIR, 'examples/simple1')


### PR DESCRIPTION
The exceptions are not often displayed due to this limitation. This change will
make the debugging easier especially when the error cannot be reproduced locally.