### PR TITLE
Fix py2 testing error due to PR #998 in nrn.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     pycodestyle
     coverage
     sh
+    pathlib
 whitelist_externals =
     make
     find

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ python =
     3.7: py3
     3.8: py3
     3.9: py3
+
 [testenv]
 envdir =
     py27{-unit,-functional,-style}: {toxworkdir}/py27


### PR DESCRIPTION
Pathlib is needed during neuron installation since this PR: neuronsimulator/nrn#998