### PR TITLE
Remove test tmp_dir in teardown

### DIFF
--- a/bluepymm/tests/test_legacy.py
+++ b/bluepymm/tests/test_legacy.py
@@ -34,6 +34,11 @@ TEST_DATA_DIR = os.path.join(BASE_DIR, 'examples/simple1')
 TMP_DIR = os.path.join(BASE_DIR, 'tmp/test_legacy')
 
 
+def teardown_module():
+    """Remove the temporary files."""
+    shutil.rmtree(TMP_DIR)
+
+
 def _new_prepare_json(original_filename, test_dir):
     """Helper function to prepare new configuration file for prepare_combos."""
     config = bluepymm.tools.load_json(original_filename)

--- a/bluepymm/tests/test_main.py
+++ b/bluepymm/tests/test_main.py
@@ -35,6 +35,11 @@ TEST_DATA_DIR = os.path.join(BASE_DIR, 'examples/simple1')
 TMP_DIR = os.path.join(BASE_DIR, 'tmp/main')
 
 
+def teardown_module():
+    """Remove the temporary files."""
+    shutil.rmtree(TMP_DIR)
+
+
 def _verify_emodel_json(filename, output_dir, nb_emodels):
     """Helper function to verify the emodel json file"""
     data_json = os.path.join(output_dir, filename)

--- a/bluepymm/tests/test_prepare_emodel_dirs.py
+++ b/bluepymm/tests/test_prepare_emodel_dirs.py
@@ -34,6 +34,11 @@ TEST_DATA_DIR = os.path.join(BASE_DIR, 'examples/simple1')
 TMP_DIR = os.path.join(BASE_DIR, 'tmp/test_prepare_emodel_dirs')
 
 
+def teardown_module():
+    """Remove the temporary files."""
+    shutil.rmtree(TMP_DIR)
+
+
 @attr('unit')
 def test_check_emodels_in_repo():
     """prepare_combos.prepare_emodel_dirs: test check_emodels_in_repo.


### PR DESCRIPTION
Currently, it's not possible to run either the unit or functional tests twice without manually deleting the output.
This PR uses the `teardown_module` of nosetests to make sure temporary directories get deleted after the tests are executed.