### PR TITLE
support relative path for template of prepare.json

### DIFF
--- a/bluepymm/prepare_combos/main.py
+++ b/bluepymm/prepare_combos/main.py
@@ -48,7 +48,7 @@ def prepare_emodels(conf_dict, continu, scores_db_path, n_processes):
         conf_dict['emodel_etype_map_path'])
 
     if "template" in conf_dict.keys():
-        hoc_template = conf_dict["template"]
+        hoc_template = os.path.abspath(conf_dict["template"])
     else:
         base_dir = os.path.abspath(os.path.dirname(__file__))
         template_dir = os.path.join(base_dir, '../templates')


### PR DESCRIPTION
@jjt20 noticed the templates specified with relative paths were not found.
Due to the `tools.cd()` calls in the code, the `cwd` is changing in between functions and sometimes within one function.
With this small change, the users can specify both absolute and relative paths in the config.
#227
