### PR TITLE
allow prepare-step to be rerun without deleting /tmp explicitly

### DIFF
--- a/bluepymm/prepare_combos/prepare_emodel_dirs.py
+++ b/bluepymm/prepare_combos/prepare_emodel_dirs.py
@@ -90,6 +90,9 @@ def convert_emodel_input(emodels_in_repo, conf_dict, continu):
             with tools.cd(tmp_emodels_dir):
                 sh.git('checkout', conf_dict['emodels_githash'])
         else:
+            if (os.path.exists(tmp_emodels_dir)
+               and os.path.isdir(tmp_emodels_dir)):
+                shutil.rmtree(tmp_emodels_dir)
             shutil.copytree(conf_dict['emodels_dir'], tmp_emodels_dir)
     return tmp_emodels_dir
 

--- a/tests/test_prepare_emodel_dirs.py
+++ b/tests/test_prepare_emodel_dirs.py
@@ -82,7 +82,10 @@ def test_convert_emodel_input_dir():
     continu = False
     _test_convert_emodel_input(TEST_DATA_DIR, emodels_in_repo, conf_dict,
                                continu)
-
+    # the second run is to make sure that the tmp_dir gets deleted and recopied
+    # in the consecutive runs
+    _test_convert_emodel_input(TEST_DATA_DIR, emodels_in_repo, conf_dict,
+                               continu)
 
 # TODO : how to do the test below?
 # @pytest.mark.unit


### PR DESCRIPTION
With this change whenever the prepare step is run a second time, it first checks the existence of the `/tmp` directory. If it exists, it gets deleted (because the existing files may be missing or corrupted) and recopied from the original source.

This saves us from deleting the `/tmp` directory manually each time, which can be challenging especially when you are using bluepymm from an interactive notebook. Users now can run the prepare command multiple times without deleting `/tmp`.