### PR TITLE
Stop using python3.7 in the tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Build a source tarball and wheel
         run: |
             pip install wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py3-{unit,functional,style}
 minversion = 4
 [gh-actions]
 python =
-    3.7: py3
     3.8: py3
     3.9: py3
     3.10: py3
@@ -11,7 +10,7 @@ python =
 
 [testenv]
 envdir =
-    py3{7,8,9,10,11,}{-unit,-functional,-style}: {toxworkdir}/py3
+    py3{8,9,10,11,}{-unit,-functional,-style}: {toxworkdir}/py3
     docs: {toxworkdir}/docs
 deps =
     NEURON-nightly
@@ -39,7 +38,7 @@ commands =
     functional: pytest --cov-append --cov-report=xml --cov-config=.coveragerc --cov=bluepymm tests -vx -m "not unit"
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.10
 changedir = docs
 deps =
     sphinx


### PR DESCRIPTION
As already stated in BluePyOpt/pull/446:

Py3.7's end of life is in 4 months.
https://endoflife.date/python

Our NEURON dependency already dropped its support.