### PR TITLE
update the patch instead of the minor of the version when tagging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: false
-          DEFAULT_BUMP: minor
+          DEFAULT_BUMP: patch
 
       - name: Build a source tarball and wheel
         run: |


### PR DESCRIPTION
I think it makes more sense to update the patch instead of the minor of the version when the github workflows automatically tags.